### PR TITLE
Expand mock querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased changes
 
-* None
+* Allow bank balances to be set in the provenance mock querier.
+* Make the internal base querier available in smart contract unit tests.
+* Use the correct mock contract address.
 
 ## Releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,13 +153,14 @@ by using our
 Whenever possible, use the standards set by the
 [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/).
 
+### Documentation Styleguide
+
+* Use [Markdown](https://daringfireball.net/projects/markdown)
+* Use a Markdown [linter](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+
 ## References
 
 The contributing document from the
 [Atom](https://github.com/atom/atom/blob/master/CONTRIBUTING.md) editor project was used as a
 template for this document.
 
-### Documentation Styleguide
-
-* Use [Markdown](https://daringfireball.net/projects/markdown)
-* Use a Markdown [linter](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)

--- a/packages/mocks/src/lib.rs
+++ b/packages/mocks/src/lib.rs
@@ -10,4 +10,4 @@ pub use common::must_read_binary_file;
 pub use marker::MarkerQuerier;
 pub use name::NameQuerier;
 
-pub use querier::{mock_dependencies, ProvenanceMockQuerier};
+pub use querier::{mock_dependencies, mock_dependencies_with_balances, ProvenanceMockQuerier};


### PR DESCRIPTION
This PR

* Allows bank balances to be set in the provenance mock querier.
* Makes the internal `base` querier available in smart contract unit tests.
* Uses the proper mock contract address.

closes: #39 