### PR TITLE
Release/0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,37 +31,37 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038089cdadfe61e4e85617d91cecec2c49f828db8e5986bb85e29d0b29c59b77"
+checksum = "bfa1715a9b71c7c31385a3f021dee2fd0a17b82043ab937467e103aa25043d2e"
 dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core",
+ "rand_core 0.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bf3da935843795a7f52678262ef06398878b0cf4c89b69612d8525ea27b84"
+checksum = "9f6e6dff07965015c4fcdf477c4becde738a2bfb40cf6239bdcea9335016c5a2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04159eec9b583671db7923ff2b979736dfb8f0152347cab9fd02373c22e1a870"
+checksum = "ac9ba1eea088e7f1ec4a7679c43adcb51e80cbc2af6a6d83d1bb652b7adaf6dc"
 dependencies = [
  "schemars",
  "serde_json",
@@ -80,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22de097cf4f7e7f575f51a22de7260932756ccfe499e005f98244a3043470e48"
+checksum = "92bdeee0ebba164ebbef9380522cc50f889db38acc1f1210f6b55ee2244b8c59"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -107,10 +96,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
+name = "crypto-bigint"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -124,16 +125,16 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
 ]
@@ -155,10 +156,11 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
+ "der",
  "elliptic-curve",
  "hmac",
  "signature",
@@ -172,7 +174,7 @@ checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core",
+ "rand_core 0.5.1",
  "serde",
  "sha2",
  "thiserror",
@@ -180,38 +182,29 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
- "bitvec",
- "digest",
+ "crypto-bigint",
  "ff",
- "funty",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "bitvec",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -231,17 +224,28 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -253,9 +257,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -269,13 +273,14 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.7.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
+checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -292,18 +297,19 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -320,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "0.14.3"
+version = "0.16.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -338,18 +344,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -384,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -402,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,12 +457,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
 ]
 
 [[package]]
@@ -470,9 +488,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -536,13 +554,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following table shows provwasm version compatibility for smart contract deve
 
 | provwasm      | wasmd          | cosmos  | provenance    | module support                 |
 | ------------- | -------------- | ------- | ------------- | ------------------------------ |
+| v0.16.0       | v0.18.0        | v0.43.0 | v1.6.0+       | attribute,marker,metadata,name |
 | v0.14.3       | v0.17.0        | v0.42.6 | v1.5.0+       | attribute,marker,metadata,name |
 | v0.14.2       | v0.17.0        | v0.42.6 | v1.5.0+       | attribute,marker,metadata,name |
 | v0.14.1       | v0.17.0        | v0.42.5 | v1.4.1+       | attribute,marker,name          |

--- a/contracts/attrs/Cargo.lock
+++ b/contracts/attrs/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "attrs"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -21,17 +21,6 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
-name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
 
 [[package]]
 name = "block-buffer"
@@ -56,37 +45,37 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038089cdadfe61e4e85617d91cecec2c49f828db8e5986bb85e29d0b29c59b77"
+checksum = "bfa1715a9b71c7c31385a3f021dee2fd0a17b82043ab937467e103aa25043d2e"
 dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core",
+ "rand_core 0.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bf3da935843795a7f52678262ef06398878b0cf4c89b69612d8525ea27b84"
+checksum = "9f6e6dff07965015c4fcdf477c4becde738a2bfb40cf6239bdcea9335016c5a2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04159eec9b583671db7923ff2b979736dfb8f0152347cab9fd02373c22e1a870"
+checksum = "ac9ba1eea088e7f1ec4a7679c43adcb51e80cbc2af6a6d83d1bb652b7adaf6dc"
 dependencies = [
  "schemars",
  "serde_json",
@@ -94,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22de097cf4f7e7f575f51a22de7260932756ccfe499e005f98244a3043470e48"
+checksum = "92bdeee0ebba164ebbef9380522cc50f889db38acc1f1210f6b55ee2244b8c59"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -110,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4abf200c2651e123595b18edf67df8702d19127b487d8b3e115dcc6c2ac0e0e"
+checksum = "e26053f14f971b05abca3be34f80c631d70c5b5b9df175e7a1d8b4aad83e40cc"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -131,10 +120,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
+name = "crypto-bigint"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -148,16 +149,16 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
 ]
@@ -179,10 +180,11 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
+ "der",
  "elliptic-curve",
  "hmac",
  "signature",
@@ -196,7 +198,7 @@ checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core",
+ "rand_core 0.5.1",
  "serde",
  "sha2",
  "thiserror",
@@ -204,38 +206,29 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
- "bitvec",
- "digest",
+ "crypto-bigint",
  "ff",
- "funty",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "bitvec",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -255,17 +248,28 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -277,9 +281,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -293,13 +297,14 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.7.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
+checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -316,11 +321,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
@@ -344,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "0.14.3"
+version = "0.16.0"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -361,18 +367,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -407,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -425,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,12 +480,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
 ]
 
 [[package]]
@@ -559,13 +577,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/contracts/attrs/Cargo.toml
+++ b/contracts/attrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "attrs"
-version = "0.6.1"
-authors = ["David Pederson <dpederson@figure.com>"]
+version = "0.7.0"
+authors = ["David Pederson <dpederson@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 
 exclude = [
@@ -28,12 +28,12 @@ backtraces = []
 
 [dependencies]
 provwasm-std = { path = "../../packages/bindings" }
-cosmwasm-std = { version = "0.14.1" }
-cosmwasm-storage = { version = "0.14.1" }
+cosmwasm-std = { version = "0.16.0", default-features = false }
+cosmwasm-storage = { version = "0.16.0" }
 schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
 provwasm-mocks = { path = "../../packages/mocks" }
-cosmwasm-schema = { version = "0.14.1" }
+cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/attrs/src/contract.rs
+++ b/contracts/attrs/src/contract.rs
@@ -26,12 +26,12 @@ pub fn instantiate(
     let bind_name_msg = bind_name(&msg.name, env.contract.address, NameBinding::Restricted)?;
 
     // Dispatch message to handler and add event attributes.
-    let mut res = Response::new();
-    res.add_message(bind_name_msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.attrs.init");
-    res.add_attribute("contract_name", msg.name);
-    res.add_attribute("contract_owner", info.sender);
+    let res = Response::new()
+        .add_message(bind_name_msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.attrs.init")
+        .add_attribute("contract_name", msg.name)
+        .add_attribute("contract_owner", info.sender);
     Ok(res)
 }
 
@@ -67,11 +67,11 @@ fn try_bind_label_name(
     attr_name: String,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
     let bind_name_msg = bind_name(&attr_name, env.contract.address, NameBinding::Restricted)?;
-    let mut res = Response::new();
-    res.add_message(bind_name_msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.attrs.try_bind_label_name");
-    res.add_attribute("attribute_name", attr_name);
+    let res = Response::new()
+        .add_message(bind_name_msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.attrs.try_bind_label_name")
+        .add_attribute("attribute_name", attr_name);
     Ok(res)
 }
 
@@ -84,11 +84,11 @@ fn try_add_label(
     let timestamp = env.block.time.nanos();
     let label = Label { text, timestamp };
     let msg = add_json_attribute(env.contract.address, &attr_name, &label)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.attrs.try_add_label");
-    res.add_attribute("attribute_name", attr_name);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.attrs.try_add_label")
+        .add_attribute("attribute_name", attr_name);
     Ok(res)
 }
 
@@ -98,11 +98,11 @@ fn try_delete_labels(
     attr_name: String,
 ) -> Result<Response<ProvenanceMsg>, ContractError> {
     let msg = delete_attributes(env.contract.address, &attr_name)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.attrs.try_delete_labels");
-    res.add_attribute("attribute_name", attr_name);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.attrs.try_delete_labels")
+        .add_attribute("attribute_name", attr_name);
     Ok(res)
 }
 
@@ -154,7 +154,7 @@ mod tests {
 
         // Ensure a message was created to bind the name to the contract address.
         assert_eq!(1, res.messages.len());
-        match &res.messages[0] {
+        match &res.messages[0].msg {
             CosmosMsg::Custom(msg) => match &msg.params {
                 ProvenanceMsgParams::Name(p) => match &p {
                     NameMsgParams::BindName { name, .. } => assert_eq!(name, "contract.pb"),
@@ -193,7 +193,7 @@ mod tests {
 
         // Ensure a message was generated for binding the label name under the contract name.
         assert_eq!(1, res.messages.len());
-        match &res.messages[0] {
+        match &res.messages[0].msg {
             CosmosMsg::Custom(msg) => match &msg.params {
                 ProvenanceMsgParams::Name(p) => match &p {
                     NameMsgParams::BindName { name, .. } => assert_eq!(name, "label.contract.pb"),
@@ -266,7 +266,7 @@ mod tests {
 
         // Ensure a message was created to add a named JSON attribute.
         assert_eq!(1, res.messages.len());
-        match &res.messages[0] {
+        match &res.messages[0].msg {
             CosmosMsg::Custom(msg) => match &msg.params {
                 ProvenanceMsgParams::Attribute(p) => match &p {
                     AttributeMsgParams::AddAttribute {
@@ -344,7 +344,7 @@ mod tests {
 
         // Ensure a message was created to delete all named JSON attributes.
         assert_eq!(1, res.messages.len());
-        match &res.messages[0] {
+        match &res.messages[0].msg {
             CosmosMsg::Custom(msg) => match &msg.params {
                 ProvenanceMsgParams::Attribute(p) => match &p {
                     AttributeMsgParams::DeleteAttribute { name, .. } => {

--- a/contracts/marker/Cargo.lock
+++ b/contracts/marker/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,37 +31,37 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038089cdadfe61e4e85617d91cecec2c49f828db8e5986bb85e29d0b29c59b77"
+checksum = "bfa1715a9b71c7c31385a3f021dee2fd0a17b82043ab937467e103aa25043d2e"
 dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core",
+ "rand_core 0.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bf3da935843795a7f52678262ef06398878b0cf4c89b69612d8525ea27b84"
+checksum = "9f6e6dff07965015c4fcdf477c4becde738a2bfb40cf6239bdcea9335016c5a2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04159eec9b583671db7923ff2b979736dfb8f0152347cab9fd02373c22e1a870"
+checksum = "ac9ba1eea088e7f1ec4a7679c43adcb51e80cbc2af6a6d83d1bb652b7adaf6dc"
 dependencies = [
  "schemars",
  "serde_json",
@@ -80,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22de097cf4f7e7f575f51a22de7260932756ccfe499e005f98244a3043470e48"
+checksum = "92bdeee0ebba164ebbef9380522cc50f889db38acc1f1210f6b55ee2244b8c59"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -96,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4abf200c2651e123595b18edf67df8702d19127b487d8b3e115dcc6c2ac0e0e"
+checksum = "e26053f14f971b05abca3be34f80c631d70c5b5b9df175e7a1d8b4aad83e40cc"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -117,10 +106,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
+name = "crypto-bigint"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -134,16 +135,16 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
 ]
@@ -165,10 +166,11 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
+ "der",
  "elliptic-curve",
  "hmac",
  "signature",
@@ -182,7 +184,7 @@ checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core",
+ "rand_core 0.5.1",
  "serde",
  "sha2",
  "thiserror",
@@ -190,38 +192,29 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
- "bitvec",
- "digest",
+ "crypto-bigint",
  "ff",
- "funty",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "bitvec",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -241,17 +234,28 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -263,9 +267,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -279,13 +283,14 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.7.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
+checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -296,7 +301,7 @@ checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "marker"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -316,11 +321,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
@@ -344,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "0.14.3"
+version = "0.16.0"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -361,18 +367,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -407,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -425,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,12 +480,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
 ]
 
 [[package]]
@@ -559,13 +577,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/contracts/marker/Cargo.toml
+++ b/contracts/marker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marker"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Phil Story <pstory@figure.com>", "David Pederson <dpederson@figure.com>", "Ken Talley <ktalley@figure.com"]
 edition = "2018"
 
@@ -29,12 +29,12 @@ backtraces = []
 
 [dependencies]
 provwasm-std = { path = "../../packages/bindings" }
-cosmwasm-std = { version = "0.14.1" }
-cosmwasm-storage = { version = "0.14.1" }
+cosmwasm-std = { version = "0.16.0" }
+cosmwasm-storage = { version = "0.16.0" }
 schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
 provwasm-mocks = { path = "../../packages/mocks" }
-cosmwasm-schema = { version = "0.14.1" }
+cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/marker/src/contract.rs
+++ b/contracts/marker/src/contract.rs
@@ -28,16 +28,13 @@ pub fn instantiate(
     let bind_name_msg = bind_name(&msg.name, env.contract.address, NameBinding::Restricted)?;
 
     // Dispatch messages to the name module handler and emit an event.
-    Ok(Response {
-        submessages: vec![],
-        messages: vec![bind_name_msg],
-        attributes: vec![
+    Ok(Response::new()
+        .add_message(bind_name_msg)
+        .add_attributes(vec![
             attr("action", "provwasm.contracts.marker.init"),
             attr("integration_test", "v2"),
             attr("contract_name", msg.name),
-        ],
-        data: None,
-    })
+        ]))
 }
 
 /// Handle messages that create and interact with with native provenance markers.
@@ -67,46 +64,46 @@ pub fn execute(
 // Create and dispatch a message that will create a new restricted marker w/ proposed status.
 fn try_create(supply: Uint128, denom: String) -> StdResult<Response<ProvenanceMsg>> {
     let msg = create_marker(supply.u128(), &denom, MarkerType::Restricted)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.create");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("marker_supply", supply);
-    res.add_attribute("marker_denom", denom);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.create")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("marker_supply", supply)
+        .add_attribute("marker_denom", denom);
     Ok(res)
 }
 
 // Create and dispatch a message that will grant all permissions to a marker for an address.
 fn try_grant_access(denom: String, address: Addr) -> StdResult<Response<ProvenanceMsg>> {
     let msg = grant_marker_access(&denom, address.clone(), MarkerAccess::all())?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.grant_access");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("marker_denom", denom);
-    res.add_attribute("marker_addr", address);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.grant_access")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("marker_denom", denom)
+        .add_attribute("marker_addr", address);
     Ok(res)
 }
 
 // Create and dispatch a message that will finalize a proposed marker.
 fn try_finalize(denom: String) -> StdResult<Response<ProvenanceMsg>> {
     let msg = finalize_marker(&denom)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.finalize");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("marker_denom", denom);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.finalize")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("marker_denom", denom);
     Ok(res)
 }
 
 // Create and dispatch a message that will activate a finalized marker.
 fn try_activate(denom: String) -> StdResult<Response<ProvenanceMsg>> {
     let msg = activate_marker(&denom)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.activate");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("marker_denom", denom);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.activate")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("marker_denom", denom);
     Ok(res)
 }
 
@@ -118,59 +115,59 @@ fn try_withdraw(
 ) -> StdResult<Response<ProvenanceMsg>> {
     let marker_denom = denom.clone();
     let msg = withdraw_coins(&marker_denom, amount.u128(), &denom, recipient.clone())?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.withdraw");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("withdraw_amount", amount);
-    res.add_attribute("withdraw_denom", denom);
-    res.add_attribute("withdraw_recipient", recipient);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.withdraw")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("withdraw_amount", amount)
+        .add_attribute("withdraw_denom", denom)
+        .add_attribute("withdraw_recipient", recipient);
     Ok(res)
 }
 
 // Create and dispatch a message that will mint coins into a marker.
 fn try_mint(amount: Uint128, denom: String) -> StdResult<Response<ProvenanceMsg>> {
     let msg = mint_marker_supply(amount.u128(), &denom)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.mint");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("mint_amount", amount);
-    res.add_attribute("mint_denom", denom);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.mint")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("mint_amount", amount)
+        .add_attribute("mint_denom", denom);
     Ok(res)
 }
 
 // Create and dispatch a message that will burn coins from a marker.
 fn try_burn(amount: Uint128, denom: String) -> StdResult<Response<ProvenanceMsg>> {
     let msg = burn_marker_supply(amount.u128(), &denom)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.burn");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("mint_amount", amount);
-    res.add_attribute("mint_denom", denom);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.burn")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("mint_amount", amount)
+        .add_attribute("mint_denom", denom);
     Ok(res)
 }
 
 // Create and dispatch a message that will cancel a marker.
 fn try_cancel(denom: String) -> StdResult<Response<ProvenanceMsg>> {
     let msg = cancel_marker(&denom)?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.cancel");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("marker_denom", denom);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.cancel")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("marker_denom", denom);
     Ok(res)
 }
 
 // Create and dispatch a message that will destroy a marker.
 fn try_destroy(denom: String) -> StdResult<Response<ProvenanceMsg>> {
     let msg = destroy_marker(denom.clone())?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.destroy");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("marker_denom", denom);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.destroy")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("marker_denom", denom);
     Ok(res)
 }
 
@@ -182,13 +179,13 @@ fn try_transfer(
     from: Addr,
 ) -> StdResult<Response<ProvenanceMsg>> {
     let msg = transfer_marker_coins(amount.u128(), &denom, to.clone(), from.clone())?;
-    let mut res = Response::new();
-    res.add_message(msg);
-    res.add_attribute("action", "provwasm.contracts.marker.transfer");
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("funds", format!("{}{}", &amount, &denom));
-    res.add_attribute("to", to);
-    res.add_attribute("from", from);
+    let res = Response::new()
+        .add_message(msg)
+        .add_attribute("action", "provwasm.contracts.marker.transfer")
+        .add_attribute("integration_test", "v2")
+        .add_attribute("funds", format!("{}{}", &amount, &denom))
+        .add_attribute("to", to)
+        .add_attribute("from", from);
     Ok(res)
 }
 
@@ -264,7 +261,7 @@ mod tests {
 
         // Create marker execute message
         let msg = ExecuteMsg::Create {
-            supply: Uint128(420),
+            supply: Uint128::new(420),
             denom: "budz".into(),
         };
 
@@ -273,7 +270,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::CreateMarker { coin, marker_type } => {
                 assert_eq!(*coin, expected_coin);
                 assert_eq!(*marker_type, MarkerType::Restricted);
@@ -302,7 +299,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::GrantMarkerAccess {
                 denom,
                 address,
@@ -333,7 +330,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::FinalizeMarker { denom } => {
                 assert_eq!(denom, "budz");
             }
@@ -358,7 +355,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::ActivateMarker { denom } => {
                 assert_eq!(denom, "budz");
             }
@@ -378,7 +375,7 @@ mod tests {
 
         // Create a withdraw execute message
         let msg = ExecuteMsg::Withdraw {
-            amount: Uint128(20),
+            amount: Uint128::new(20),
             denom: "budz".into(),
         };
 
@@ -387,7 +384,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::WithdrawCoins {
                 marker_denom,
                 coin,
@@ -413,7 +410,7 @@ mod tests {
 
         // Create a mint coins marker handler message
         let msg = ExecuteMsg::Mint {
-            amount: Uint128(20),
+            amount: Uint128::new(20),
             denom: "budz".into(),
         };
 
@@ -422,7 +419,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::MintMarkerSupply { coin } => assert_eq!(*coin, expected_coin),
             _ => panic!("expected marker mint params"),
         }
@@ -440,7 +437,7 @@ mod tests {
 
         // Create a burn coins marker handler message
         let msg = ExecuteMsg::Burn {
-            amount: Uint128(20),
+            amount: Uint128::new(20),
             denom: "budz".into(),
         };
 
@@ -449,7 +446,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::BurnMarkerSupply { coin } => assert_eq!(*coin, expected_coin),
             _ => panic!("expected marker burn params"),
         }
@@ -472,7 +469,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::CancelMarker { denom } => assert_eq!(denom, "budz"),
             _ => panic!("expected marker cancel params"),
         }
@@ -495,7 +492,7 @@ mod tests {
         assert_eq!(1, res.messages.len());
 
         // Assert the correct params were created
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::DestroyMarker { denom } => assert_eq!(denom, "budz"),
             _ => panic!("expected marker destroy params"),
         }
@@ -510,7 +507,7 @@ mod tests {
 
         // Create a transfer execute message
         let msg = ExecuteMsg::Transfer {
-            amount: Uint128(20),
+            amount: Uint128::new(20),
             denom: "budz".into(),
             to: "toaddress".into(),
         };
@@ -521,7 +518,7 @@ mod tests {
 
         // Assert the correct params were created
         let expected_coin = coin(20, "budz");
-        match unwrap_marker_params(&res.messages[0]) {
+        match unwrap_marker_params(&res.messages[0].msg) {
             MarkerMsgParams::TransferMarkerCoins { coin, to, from } => {
                 assert_eq!(*coin, expected_coin);
                 assert_eq!(*to, Addr::unchecked("toaddress"));

--- a/contracts/name/Cargo.lock
+++ b/contracts/name/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,37 +31,37 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038089cdadfe61e4e85617d91cecec2c49f828db8e5986bb85e29d0b29c59b77"
+checksum = "bfa1715a9b71c7c31385a3f021dee2fd0a17b82043ab937467e103aa25043d2e"
 dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core",
+ "rand_core 0.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bf3da935843795a7f52678262ef06398878b0cf4c89b69612d8525ea27b84"
+checksum = "9f6e6dff07965015c4fcdf477c4becde738a2bfb40cf6239bdcea9335016c5a2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04159eec9b583671db7923ff2b979736dfb8f0152347cab9fd02373c22e1a870"
+checksum = "ac9ba1eea088e7f1ec4a7679c43adcb51e80cbc2af6a6d83d1bb652b7adaf6dc"
 dependencies = [
  "schemars",
  "serde_json",
@@ -80,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22de097cf4f7e7f575f51a22de7260932756ccfe499e005f98244a3043470e48"
+checksum = "92bdeee0ebba164ebbef9380522cc50f889db38acc1f1210f6b55ee2244b8c59"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -96,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4abf200c2651e123595b18edf67df8702d19127b487d8b3e115dcc6c2ac0e0e"
+checksum = "e26053f14f971b05abca3be34f80c631d70c5b5b9df175e7a1d8b4aad83e40cc"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -117,10 +106,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
+name = "crypto-bigint"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -134,16 +135,16 @@ checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
 ]
@@ -165,10 +166,11 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
+ "der",
  "elliptic-curve",
  "hmac",
  "signature",
@@ -182,7 +184,7 @@ checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core",
+ "rand_core 0.5.1",
  "serde",
  "sha2",
  "thiserror",
@@ -190,38 +192,29 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
- "bitvec",
- "digest",
+ "crypto-bigint",
  "ff",
- "funty",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "bitvec",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -241,17 +234,28 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -263,9 +267,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -279,13 +283,14 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "k256"
-version = "0.7.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf02ecc966e1b7e8db1c81ac8f321ba24d1cfab5b634961fab10111f015858e1"
+checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -296,7 +301,7 @@ checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "name"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -316,11 +321,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
@@ -344,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "0.14.3"
+version = "0.16.0"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -361,18 +367,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -407,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -425,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,12 +480,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
 ]
 
 [[package]]
@@ -559,13 +577,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/contracts/name/Cargo.toml
+++ b/contracts/name/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "name"
-version = "0.6.1"
-authors = ["David Pederson <dpederson@figure.com>"]
+version = "0.7.0"
+authors = ["David Pederson <dpederson@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 
 exclude = [
@@ -28,12 +28,12 @@ backtraces = []
 
 [dependencies]
 provwasm-std = { path = "../../packages/bindings" }
-cosmwasm-std = { version = "0.14.1" }
-cosmwasm-storage = { version = "0.14.1" }
+cosmwasm-std = { version = "0.16.0" }
+cosmwasm-storage = { version = "0.16.0" }
 schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 [dev-dependencies]
 provwasm-mocks = { path = "../../packages/mocks" }
-cosmwasm-schema = { version = "0.14.1" }
+cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/name/src/contract.rs
+++ b/contracts/name/src/contract.rs
@@ -27,12 +27,12 @@ pub fn instantiate(
     let bind_name_msg = bind_name(&msg.name, env.contract.address, NameBinding::Restricted)?;
 
     // Dispatch bind name message and add event attributes.
-    let mut res = Response::new();
-    res.add_message(bind_name_msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.name.init");
-    res.add_attribute("contract_name", msg.name);
-    res.add_attribute("contract_owner", info.sender);
+    let res = Response::new()
+        .add_message(bind_name_msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.name.init")
+        .add_attribute("contract_name", msg.name)
+        .add_attribute("contract_owner", info.sender);
     Ok(res)
 }
 
@@ -71,12 +71,12 @@ pub fn try_bind_prefix(
     let bind_name_msg = bind_name(&name, env.contract.address.clone(), NameBinding::Restricted)?;
 
     // Dispatch message to handler and emit events
-    let mut res = Response::new();
-    res.add_message(bind_name_msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.name.try_bind_prefix");
-    res.add_attribute("name", name);
-    res.add_attribute("address", env.contract.address);
+    let res = Response::new()
+        .add_message(bind_name_msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.name.try_bind_prefix")
+        .add_attribute("name", name)
+        .add_attribute("address", env.contract.address);
     Ok(res)
 }
 
@@ -101,11 +101,11 @@ pub fn try_unbind_prefix(
     let unbind_name_msg = unbind_name(&name)?;
 
     // Dispatch message to handler and emit events
-    let mut res = Response::new();
-    res.add_message(unbind_name_msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.name.try_unbind_prefix");
-    res.add_attribute("name", name);
+    let res = Response::new()
+        .add_message(unbind_name_msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.name.try_unbind_prefix")
+        .add_attribute("name", name);
     Ok(res)
 }
 
@@ -156,7 +156,7 @@ mod tests {
         // Ensure a message was created to bind the name to the contract address.
         let res = instantiate(deps.as_mut(), env, info, msg).unwrap();
         assert_eq!(1, res.messages.len());
-        match &res.messages[0] {
+        match &res.messages[0].msg {
             CosmosMsg::Custom(msg) => match &msg.params {
                 ProvenanceMsgParams::Name(p) => match &p {
                     NameMsgParams::BindName { name, .. } => assert_eq!(name, "contract.pb"),
@@ -189,7 +189,7 @@ mod tests {
 
         // Assert the correct message was created
         assert_eq!(1, res.messages.len());
-        match &res.messages[0] {
+        match &res.messages[0].msg {
             CosmosMsg::Custom(msg) => match &msg.params {
                 ProvenanceMsgParams::Name(p) => match &p {
                     NameMsgParams::BindName { name, .. } => assert_eq!(name, "test.contract.pb"),
@@ -221,7 +221,7 @@ mod tests {
 
         // Assert the correct message was created
         assert_eq!(1, res.messages.len());
-        match &res.messages[0] {
+        match &res.messages[0].msg {
             CosmosMsg::Custom(msg) => match &msg.params {
                 ProvenanceMsgParams::Name(p) => match &p {
                     NameMsgParams::DeleteName { name, .. } => assert_eq!(name, "test.contract.pb"),

--- a/contracts/scope/Cargo.lock
+++ b/contracts/scope/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,37 +31,37 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.4.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038089cdadfe61e4e85617d91cecec2c49f828db8e5986bb85e29d0b29c59b77"
+checksum = "bfa1715a9b71c7c31385a3f021dee2fd0a17b82043ab937467e103aa25043d2e"
 dependencies = [
  "digest",
  "ed25519-zebra",
  "k256",
- "rand_core",
+ "rand_core 0.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bf3da935843795a7f52678262ef06398878b0cf4c89b69612d8525ea27b84"
+checksum = "9f6e6dff07965015c4fcdf477c4becde738a2bfb40cf6239bdcea9335016c5a2"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04159eec9b583671db7923ff2b979736dfb8f0152347cab9fd02373c22e1a870"
+checksum = "ac9ba1eea088e7f1ec4a7679c43adcb51e80cbc2af6a6d83d1bb652b7adaf6dc"
 dependencies = [
  "schemars",
  "serde_json",
@@ -80,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22de097cf4f7e7f575f51a22de7260932756ccfe499e005f98244a3043470e48"
+checksum = "92bdeee0ebba164ebbef9380522cc50f889db38acc1f1210f6b55ee2244b8c59"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -96,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4abf200c2651e123595b18edf67df8702d19127b487d8b3e115dcc6c2ac0e0e"
+checksum = "e26053f14f971b05abca3be34f80c631d70c5b5b9df175e7a1d8b4aad83e40cc"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -120,10 +109,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
+name = "crypto-bigint"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -137,16 +138,16 @@ checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "der"
-version = "0.1.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
 ]
@@ -168,10 +169,11 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.10.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
+ "der",
  "elliptic-curve",
  "hmac",
  "signature",
@@ -185,7 +187,7 @@ checksum = "0a128b76af6dd4b427e34a6fd43dc78dbfe73672ec41ff615a2414c1a0ad0409"
 dependencies = [
  "curve25519-dalek",
  "hex",
- "rand_core",
+ "rand_core 0.5.1",
  "serde",
  "sha2",
  "thiserror",
@@ -193,38 +195,29 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.8.5"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2db227e61a43a34915680bdda462ec0e212095518020a88a1f91acd16092c39"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
- "bitvec",
- "digest",
+ "crypto-bigint",
  "ff",
- "funty",
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "ff"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
- "bitvec",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -244,17 +237,28 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "group"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -266,9 +270,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest",
@@ -282,9 +286,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "k256"
-version = "0.7.3"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4476a0808212a9e81ce802eb1a0cfc60e73aea296553bacc0fac7e1268bc572a"
+checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -306,11 +310,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
 dependencies = [
  "der",
+ "spki",
 ]
 
 [[package]]
@@ -334,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "0.14.3"
+version = "0.16.0"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -351,18 +356,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -397,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "scope"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -411,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -429,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -475,12 +483,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
 ]
 
 [[package]]
@@ -563,13 +580,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/contracts/scope/Cargo.toml
+++ b/contracts/scope/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scope"
-version = "0.1.0"
-authors = ["David Pederson <dpederson@figure.com>"]
+version = "0.2.0"
+authors = ["David Pederson <dpederson@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 
 exclude = [
@@ -28,13 +28,13 @@ backtraces = []
 
 [dependencies]
 provwasm-std = { path = "../../packages/bindings" }
-cosmwasm-std = { version = "0.14.1" }
-cosmwasm-storage = { version = "0.14.1" }
+cosmwasm-std = { version = "0.16.0", default-features = false }
+cosmwasm-storage = { version = "0.16.0" }
 schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.20" }
 
 
 [dev-dependencies]
 provwasm-mocks = { path = "../../packages/mocks" }
-cosmwasm-schema = { version = "0.14.1" }
+cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/scope/src/contract.rs
+++ b/contracts/scope/src/contract.rs
@@ -28,11 +28,11 @@ pub fn instantiate(
     )?;
 
     // Dispatch message to handler and emit events
-    let mut res: Response<ProvenanceMsg> = Response::new();
-    res.add_message(bind_name_msg);
-    res.add_attribute("integration_test", "v2");
-    res.add_attribute("action", "provwasm.contracts.scope.init");
-    res.add_attribute("name", msg.name);
+    let res: Response<ProvenanceMsg> = Response::new()
+        .add_message(bind_name_msg)
+        .add_attribute("integration_test", "v2")
+        .add_attribute("action", "provwasm.contracts.scope.init")
+        .add_attribute("name", msg.name);
     Ok(res)
 }
 

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provwasm-std"
-version = "0.14.3"
+version = "0.16.0"
 authors = ["David Pederson <dpederson@figure.com>", "Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,9 +13,9 @@ categories = ["api-bindings", "cryptography::cryptocurrencies", "wasm"]
 backtraces = []
 
 [dependencies]
-cosmwasm-std = { version = "0.14.1", features = ["staking"] }
+cosmwasm-std = { version = "0.16.0", default-features = false }
 schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.14.1" }
+cosmwasm-schema = { version = "0.16.0" }

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -63,8 +63,7 @@ fn create_name_msg(params: NameMsgParams) -> CosmosMsg<ProvenanceMsg> {
 ///     address: Addr,
 /// ) -> StdResult<Response<ProvenanceMsg>> {
 ///    let msg = bind_name(&name, address, NameBinding::Restricted)?;
-///    let mut res = Response::new();
-///    res.add_message(msg);
+///    let mut res = Response::new().add_message(msg);
 ///    Ok(res)
 /// }
 /// ```
@@ -92,8 +91,7 @@ pub fn bind_name<S: Into<String>, H: Into<Addr>>(
 /// // Unbind a name
 /// fn exec_unbind_name(name: String) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = unbind_name(&name)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -152,8 +150,7 @@ fn create_attribute_msg(params: AttributeMsgParams) -> CosmosMsg<ProvenanceMsg> 
 ///         Binary::from(greeting.as_bytes()),
 ///         AttributeValueType::String,
 ///     )?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -198,8 +195,7 @@ pub fn add_attribute<H: Into<Addr>, S: Into<String>, B: Into<Binary>>(
 ///     let timestamp = env.block.time.nanos();
 ///     let label = Label { text, timestamp };
 ///     let msg = add_json_attribute(address, &attr_name, &label)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 ///
@@ -238,8 +234,7 @@ pub fn add_json_attribute<H: Into<Addr>, S: Into<String>, T: Serialize + ?Sized>
 /// ) -> StdResult<Response<ProvenanceMsg>> {
 ///     let attr_name = String::from("label.my-contract.sc.pb");
 ///     let msg = delete_attributes(address, &attr_name)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -324,8 +319,7 @@ fn create_marker_msg(params: MarkerMsgParams) -> CosmosMsg<ProvenanceMsg> {
 ///     denom: String,
 /// ) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = create_marker(amount, &denom, MarkerType::Coin)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -357,8 +351,7 @@ pub fn create_marker<S: Into<String>>(
 /// ) -> StdResult<Response<ProvenanceMsg>> {
 ///     let permissions = vec![MarkerAccess::Burn, MarkerAccess::Mint];
 ///     let msg = grant_marker_access(&denom, address, permissions)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -389,8 +382,7 @@ pub fn grant_marker_access<S: Into<String>, H: Into<Addr>>(
 ///     address: Addr,
 /// ) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = revoke_marker_access(&denom, address)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -416,8 +408,7 @@ pub fn revoke_marker_access<S: Into<String>, H: Into<Addr>>(
 /// // Create and dispatch a message that will finalize a proposed marker.
 /// fn try_finalize_marker(denom: String) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = finalize_marker(&denom)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -439,8 +430,7 @@ pub fn finalize_marker<S: Into<String>>(denom: S) -> StdResult<CosmosMsg<Provena
 /// // Create and dispatch a message that will activate a finalized marker.
 /// fn try_activate_marker(denom: String) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = activate_marker(&denom)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -462,8 +452,7 @@ pub fn activate_marker<S: Into<String>>(denom: S) -> StdResult<CosmosMsg<Provena
 /// // Create and dispatch a message that will cancel a marker.
 /// fn try_cancel_marker(denom: String) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = cancel_marker(&denom)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -485,8 +474,7 @@ pub fn cancel_marker<S: Into<String>>(denom: S) -> StdResult<CosmosMsg<Provenanc
 /// // Create and dispatch a message that will destroy a marker.
 /// fn try_destroy_marker(denom: String) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = destroy_marker(&denom)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -508,8 +496,7 @@ pub fn destroy_marker<S: Into<String>>(denom: S) -> StdResult<CosmosMsg<Provenan
 /// // Create and dispatch a message that will mint marker supply.
 /// fn try_mint_marker(amount: u128, denom: String) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = mint_marker_supply(amount, &denom)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -538,8 +525,7 @@ pub fn mint_marker_supply<S: Into<String>>(
 /// // Create and dispatch a message that will burn marker supply.
 /// fn try_burn_marker(amount: u128, denom: String) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = burn_marker_supply(amount, &denom)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -573,8 +559,7 @@ pub fn burn_marker_supply<S: Into<String>>(
 ///     recipient: Addr,
 /// ) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = withdraw_coins(&marker_denom, amount, &denom, recipient)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```
@@ -613,8 +598,7 @@ pub fn withdraw_coins<S: Into<String>, H: Into<Addr>>(
 ///     from: Addr,
 /// ) -> StdResult<Response<ProvenanceMsg>> {
 ///     let msg = transfer_marker_coins(amount, &denom, to, from)?;
-///     let mut res = Response::new();
-///     res.add_message(msg);
+///     let mut res = Response::new().add_message(msg);
 ///     Ok(res)
 /// }
 /// ```

--- a/packages/mocks/Cargo.toml
+++ b/packages/mocks/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["provenance", "blockchain", "smart-contracts", "defi", "finance"]
 categories = ["development-tools::testing", "cryptography::cryptocurrencies", "wasm"]
 
 [dependencies]
-provwasm-std = { path = "../bindings", version = "0.14.3" }
-cosmwasm-std = { version = "0.14.1", features = ["staking"] }
+provwasm-std = { path = "../bindings", version = "0.16.0" }
+cosmwasm-std = { version = "0.16.0", features = ["staking"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/mocks/src/querier.rs
+++ b/packages/mocks/src/querier.rs
@@ -54,10 +54,10 @@ impl ProvenanceMockQuerier {
     pub fn handle_query(&self, request: &QueryRequest<ProvenanceQuery>) -> QuerierResult {
         match request {
             QueryRequest::Custom(custom) => match &custom.params {
-                ProvenanceQueryParams::Attribute(p) => self.attribute.query(&p),
-                ProvenanceQueryParams::Marker(p) => self.marker.query(&p),
-                ProvenanceQueryParams::Name(p) => self.name.query(&p),
-                ProvenanceQueryParams::Metadata(p) => self.metadata.query(&p),
+                ProvenanceQueryParams::Attribute(p) => self.attribute.query(p),
+                ProvenanceQueryParams::Marker(p) => self.marker.query(p),
+                ProvenanceQueryParams::Name(p) => self.name.query(p),
+                ProvenanceQueryParams::Metadata(p) => self.metadata.query(p),
             },
             QueryRequest::Bank(q) => self.base.handle_query(&QueryRequest::Bank(q.clone())),
             #[cfg(feature = "staking")]


### PR DESCRIPTION
This PR will upgrade provwasm to use cosmwasm 0.16.0 with compatibility for wasmd 0.18 and cosmos sdk 0.43.0