### PR TITLE
remove `build_init` step from workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,9 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
-  build_init:
-    runs-on: ubuntu-latest
-    name: Build Init
-    steps:
-      - id: version
-        run: echo "::set-output name=version::${GITHUB_REF##*/}"
 
   create_release:
     runs-on: ubuntu-latest
-    needs:
-      - build_init
     name: Create Release
     steps:
       - name: Checkout
@@ -41,7 +33,7 @@ jobs:
       - name: Build wasm binaries
         run: |
           make contracts
-      - name: Create release ${{ needs.build_init.outputs.version }}
+      - name: Create release
         uses: softprops/action-gh-release@v1
         id: create_release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,17 +18,8 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
-  build_init:
-    runs-on: ubuntu-latest
-    name: Build Init
-    steps:
-      - id: version
-        run: echo "::set-output name=version::${GITHUB_REF##*/}"
-
   test_tutorial_smart_contract:
     runs-on: ubuntu-latest
-    needs:
-      - build_init
     name: Test Tutorial Smart Contract
     steps:
       - name: Checkout
@@ -51,8 +42,6 @@ jobs:
 
   test_attrs_smart_contract:
     runs-on: ubuntu-latest
-    needs:
-      - build_init
     name: Test Attr Smart Contract
     steps:
       - name: Checkout
@@ -75,8 +64,6 @@ jobs:
 
   test_marker_smart_contract:
     runs-on: ubuntu-latest
-    needs:
-      - build_init
     name: Test Marker Smart Contract
     steps:
       - name: Checkout
@@ -99,8 +86,6 @@ jobs:
 
   test_msgfees_smart_contract:
     runs-on: ubuntu-latest
-    needs:
-      - build_init
     name: Test MsgFees Smart Contract
     steps:
       - name: Checkout
@@ -123,8 +108,6 @@ jobs:
 
   test_name_smart_contract:
     runs-on: ubuntu-latest
-    needs:
-      - build_init
     name: Test Name Smart Contract
     steps:
       - name: Checkout
@@ -147,8 +130,6 @@ jobs:
 
   test_scope_smart_contract:
     runs-on: ubuntu-latest
-    needs:
-      - build_init
     name: Test Scope Smart Contract
     steps:
       - name: Checkout


### PR DESCRIPTION
this step was unnecessary and would throw deprecation warnings since `set-output` is deprecated.

this is part of the provenance parent project [issue #1200](https://github.com/provenance-io/provenance/issues/1200)
